### PR TITLE
修复 1. RichEdit DPI缩放问题 2 RichEdit return被拦截导致无无法响应回车 3 m_rcItem和m_rcPaint无需要再DPI处理,回退到之前代码

### DIFF
--- a/DuiLib/Control/UILabel.cpp
+++ b/DuiLib/Control/UILabel.cpp
@@ -104,6 +104,8 @@ namespace DuiLib {
 					m_cxyFixedLast.cy = m_pManager->GetFontInfo (m_iFont)->tm.tmHeight + 8;
 					m_cxyFixedLast.cy += GetManager ()->GetDPIObj ()->Scale (m_rcTextPadding.top + m_rcTextPadding.bottom);
 				}
+				else
+					m_cxyFixedLast.cy = GetManager()->GetDPIObj()->Scale(m_cxyFixed.cy);
 				// 宽度
 				if (m_cxyFixedLast.cx == 0) {
 					if (m_bAutoCalcWidth) {
@@ -117,6 +119,8 @@ namespace DuiLib {
 						m_cxyFixedLast.cx = rcText.right - rcText.left + GetManager ()->GetDPIObj ()->Scale (m_rcTextPadding.left + m_rcTextPadding.right);
 					}
 				}
+				else
+					m_cxyFixedLast.cx = GetManager()->GetDPIObj()->Scale(m_cxyFixed.cx);
 			} else if (m_cxyFixedLast.cy == 0) {
 				if (m_bAutoCalcHeight) {
 					RECT rcText = { 0, 0, m_cxyFixedLast.cx, 9999 };

--- a/DuiLib/Control/UIRichEdit.cpp
+++ b/DuiLib/Control/UIRichEdit.cpp
@@ -1561,7 +1561,7 @@ namespace DuiLib {
 	HRESULT CRichEditUI::TxSendMessage (UINT msg, WPARAM wparam, LPARAM lparam, LRESULT *plresult) const {
 		if (m_pTwh) {
 			if (msg == WM_KEYDOWN && TCHAR (wparam) == VK_RETURN) {
-				if (!m_bWantReturn || (::GetKeyState (VK_CONTROL) < 0 && !m_bWantCtrlReturn)) {
+				if (m_bWantReturn || (::GetKeyState (VK_CONTROL) < 0 && m_bWantCtrlReturn)) {
 					if (m_pManager) m_pManager->SendNotify ((CControlUI*) this, DUI_MSGTYPE_RETURN);
 					return S_OK;
 				}

--- a/DuiLib/Core/UIControl.cpp
+++ b/DuiLib/Core/UIControl.cpp
@@ -924,24 +924,12 @@ namespace DuiLib {
 		// 绘制循序：背景颜色->背景图->状态图->文本->边框
 		int nBorderSize = { 0 };
 		SIZE cxyBorderRound = { 0 };
-		RECT rcItem = { 0 };
-		RECT tempRCPaint = { 0 };
-		if (m_pManager != 0) {
-			nBorderSize = GetManager()->GetDPIObj()->Scale(m_nBorderSize);
-			cxyBorderRound = GetManager()->GetDPIObj()->Scale(m_cxyBorderRound);
-			rcItem = GetManager()->GetDPIObj()->Scale(m_rcItem);
-			tempRCPaint = GetManager()->GetDPIObj()->Scale(m_rcPaint);
-		}
-		else {
-			nBorderSize = m_nBorderSize;
-			cxyBorderRound = m_cxyBorderRound;
-			rcItem = m_rcItem;
-			tempRCPaint = m_rcPaint;
-		}
+		nBorderSize = GetBorderSize();
+		cxyBorderRound = GetBorderRound();
 
 		if (cxyBorderRound.cx > 0 || cxyBorderRound.cy > 0) {
 			CRenderClip roundClip;
-			CRenderClip::GenerateRoundClip (hDC, tempRCPaint, rcItem, cxyBorderRound.cx, cxyBorderRound.cy, roundClip);
+			CRenderClip::GenerateRoundClip (hDC, m_rcPaint, m_rcItem, cxyBorderRound.cx, cxyBorderRound.cy, roundClip);
 			PaintBkColor(hDC);
 			PaintBkImage (hDC);
 			PaintStatusImage (hDC);
@@ -965,47 +953,36 @@ namespace DuiLib {
 		if (m_dwBackColor != 0) {
 			int nBorderSize = { 0 };
 			SIZE cxyBorderRound = { 0 };
-			RECT rcItem = { 0 };
-			RECT tempRCPaint = { 0 };
-			if (m_pManager != 0) {
-				nBorderSize = GetManager()->GetDPIObj()->Scale(m_nBorderSize);
-				cxyBorderRound = GetManager()->GetDPIObj()->Scale(m_cxyBorderRound);
-				rcItem = GetManager()->GetDPIObj()->Scale(m_rcItem);
-				tempRCPaint = GetManager()->GetDPIObj()->Scale(m_rcPaint);
-			}
-			else {
-				nBorderSize = m_nBorderSize;
-				cxyBorderRound = m_cxyBorderRound;
-				rcItem = m_rcItem;
-				tempRCPaint = m_rcPaint;
-			}
+			nBorderSize = GetBorderSize();
+			cxyBorderRound = GetBorderRound();
+
 			bool bVer = (!FawTools::is_equal_nocase(m_sGradient, _T("hor")));
 			if (m_dwBackColor2 != 0) {
 				if (m_dwBackColor3 != 0) {
-					auto RealBottom = rcItem.bottom;
-					rcItem.bottom = (rcItem.bottom + rcItem.top) / 2;
-					CRenderEngine::DrawGradient(hDC, rcItem, GetAdjustColor(m_dwBackColor), GetAdjustColor(m_dwBackColor2), bVer, 8);
-					rcItem.top = rcItem.bottom;
-					rcItem.bottom = RealBottom;
-					CRenderEngine::DrawGradient(hDC, rcItem, GetAdjustColor(m_dwBackColor2), GetAdjustColor(m_dwBackColor3), bVer, 8);
+					auto RealBottom = m_rcItem.bottom;
+					m_rcItem.bottom = (m_rcItem.bottom + m_rcItem.top) / 2;
+					CRenderEngine::DrawGradient(hDC, m_rcItem, GetAdjustColor(m_dwBackColor), GetAdjustColor(m_dwBackColor2), bVer, 8);
+					m_rcItem.top = m_rcItem.bottom;
+					m_rcItem.bottom = RealBottom;
+					CRenderEngine::DrawGradient(hDC, m_rcItem, GetAdjustColor(m_dwBackColor2), GetAdjustColor(m_dwBackColor3), bVer, 8);
 				}
 				else {
-					CRenderEngine::DrawGradient(hDC, rcItem, GetAdjustColor(m_dwBackColor), GetAdjustColor(m_dwBackColor2), bVer, 16);
+					CRenderEngine::DrawGradient(hDC, m_rcItem, GetAdjustColor(m_dwBackColor), GetAdjustColor(m_dwBackColor2), bVer, 16);
 				}
 			}
 			else {
 				// 矩形很窄,不必再考虑圆角边框,直接 DrawColor, 或者矩形无圆角,直接 DrawColor  
-				if (rcItem.right - rcItem.left <= 4 || rcItem.bottom - rcItem.top <= 4 || (cxyBorderRound.cx == 0 && cxyBorderRound.cy == 0))
+				if (m_rcItem.right - m_rcItem.left <= 4 || m_rcItem.bottom - m_rcItem.top <= 4 || (cxyBorderRound.cx == 0 && cxyBorderRound.cy == 0))
 				{
-					if (m_dwBackColor >= 0xFF000000) CRenderEngine::DrawColor(hDC, tempRCPaint, GetAdjustColor(m_dwBackColor));
-					else CRenderEngine::DrawColor(hDC, rcItem, GetAdjustColor(m_dwBackColor));
+					if (m_dwBackColor >= 0xFF000000) CRenderEngine::DrawColor(hDC, m_rcPaint, GetAdjustColor(m_dwBackColor));
+					else CRenderEngine::DrawColor(hDC, m_rcItem, GetAdjustColor(m_dwBackColor));
 				}
 				else
 				{
 					const auto dwBackColor = GetAdjustColor(m_dwBackColor);
 					const auto dwBorderColor = GetAdjustColor((IsFocused() && m_dwFocusBorderColor != 0) ? m_dwFocusBorderColor : m_dwBorderColor);
 					//此函数用于画矩形,高度为1的线是画不出来的
-					CRenderEngine::DrawRoundRectangle(hDC, rcItem.left, rcItem.top, rcItem.right - rcItem.left - 1, rcItem.bottom - rcItem.top - 1, cxyBorderRound.cx, 0, dwBorderColor, true, dwBackColor);
+					CRenderEngine::DrawRoundRectangle(hDC, m_rcItem.left, m_rcItem.top, m_rcItem.right - m_rcItem.left - 1, m_rcItem.bottom - m_rcItem.top - 1, cxyBorderRound.cx, 0, dwBorderColor, true, dwBackColor);
 				}
 			}
 		}
@@ -1022,13 +999,7 @@ namespace DuiLib {
 	}
 
 	void CControlUI::PaintForeColor (HDC hDC) {
-		RECT rcItem = { 0 };
-		if (m_pManager != 0) 
-			rcItem = GetManager()->GetDPIObj()->Scale(m_rcItem);
-		else
-			rcItem = m_rcItem;
-
-		CRenderEngine::DrawColor (hDC, rcItem, GetAdjustColor (m_dwForeColor));
+		CRenderEngine::DrawColor (hDC, m_rcItem, GetAdjustColor (m_dwForeColor));
 	}
 
 	void CControlUI::PaintForeImage (HDC hDC) {
@@ -1044,59 +1015,50 @@ namespace DuiLib {
 		int nBorderSize;
 		SIZE cxyBorderRound = { 0 };
 		RECT rcBorderSize = { 0 };
-		RECT rcItem = { 0 };
-		RECT tempRCPaint = { 0 };
-		if (m_pManager) {
-			nBorderSize = GetManager ()->GetDPIObj ()->Scale (m_nBorderSize);
-			cxyBorderRound = GetManager ()->GetDPIObj ()->Scale (m_cxyBorderRound);
-			rcBorderSize = GetManager ()->GetDPIObj ()->Scale (m_rcBorderSize);
-			rcItem = GetManager()->GetDPIObj()->Scale(m_rcItem);
-			tempRCPaint = GetManager()->GetDPIObj()->Scale(m_rcPaint);
-		} else {
-			nBorderSize = m_nBorderSize;
-			cxyBorderRound = m_cxyBorderRound;
+		nBorderSize = GetBorderSize();
+		cxyBorderRound = GetBorderRound();
+		if (m_pManager)
+			rcBorderSize = GetManager()->GetDPIObj()->Scale(m_rcBorderSize);
+		else
 			rcBorderSize = m_rcBorderSize;
-			rcItem = GetManager()->GetDPIObj()->Scale(m_rcItem);
-			tempRCPaint = GetManager()->GetDPIObj()->Scale(m_rcPaint);
-		}
 
 		if (m_dwBorderColor != 0 || m_dwFocusBorderColor != 0) {
 			//画圆角边框
 			if (nBorderSize > 0 && (cxyBorderRound.cx > 0 || cxyBorderRound.cy > 0)) {
 				if (IsFocused () && m_dwFocusBorderColor != 0)
-					CRenderEngine::DrawRoundRect (hDC, rcItem, nBorderSize, cxyBorderRound.cx, cxyBorderRound.cy, GetAdjustColor (m_dwFocusBorderColor), m_nBorderStyle);
+					CRenderEngine::DrawRoundRect (hDC, m_rcItem, nBorderSize, cxyBorderRound.cx, cxyBorderRound.cy, GetAdjustColor (m_dwFocusBorderColor), m_nBorderStyle);
 				else
-					CRenderEngine::DrawRoundRect (hDC, rcItem, nBorderSize, cxyBorderRound.cx, cxyBorderRound.cy, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
+					CRenderEngine::DrawRoundRect (hDC, m_rcItem, nBorderSize, cxyBorderRound.cx, cxyBorderRound.cy, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 			} else {
 				if (IsFocused () && m_dwFocusBorderColor != 0 && nBorderSize > 0) {
-					CRenderEngine::DrawRect (hDC, rcItem, nBorderSize, GetAdjustColor (m_dwFocusBorderColor), m_nBorderStyle);
+					CRenderEngine::DrawRect (hDC, m_rcItem, nBorderSize, GetAdjustColor (m_dwFocusBorderColor), m_nBorderStyle);
 				} else if (rcBorderSize.left > 0 || rcBorderSize.top > 0 || rcBorderSize.right > 0 || rcBorderSize.bottom > 0) {
 					RECT rcBorder = { 0 };
 
 					if (rcBorderSize.left > 0) {
-						rcBorder = rcItem;
+						rcBorder = m_rcItem;
 						rcBorder.right = rcBorder.left;
 						CRenderEngine::DrawLine (hDC, rcBorder, rcBorderSize.left, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 					}
 					if (rcBorderSize.top > 0) {
-						rcBorder = rcItem;
+						rcBorder = m_rcItem;
 						rcBorder.bottom = rcBorder.top;
 						CRenderEngine::DrawLine (hDC, rcBorder, rcBorderSize.top, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 					}
 					if (rcBorderSize.right > 0) {
-						rcBorder = rcItem;
+						rcBorder = m_rcItem;
 						rcBorder.right -= 1;
 						rcBorder.left = rcBorder.right;
 						CRenderEngine::DrawLine (hDC, rcBorder, rcBorderSize.right, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 					}
 					if (rcBorderSize.bottom > 0) {
-						rcBorder = rcItem;
+						rcBorder = m_rcItem;
 						rcBorder.bottom -= 1;
 						rcBorder.top = rcBorder.bottom;
 						CRenderEngine::DrawLine (hDC, rcBorder, rcBorderSize.bottom, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 					}
 				} else if (nBorderSize > 0) {
-					CRenderEngine::DrawRect (hDC, rcItem, nBorderSize, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
+					CRenderEngine::DrawRect (hDC, m_rcItem, nBorderSize, GetAdjustColor (m_dwBorderColor), m_nBorderStyle);
 				}
 			}
 		}

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -699,9 +699,13 @@ namespace DuiLib {
 		switch (uMsg) {
 		case WM_KEYDOWN:
 		{
+			if (wParam == VK_RETURN) {
+				if (m_pFocus && m_pFocus->IsVisible() && m_pFocus->IsEnabled() && m_pFocus->GetClass().find(_T("RichEdit")) != faw::string_t::npos)
+					if (dynamic_cast<CRichEditUI*>(m_pFocus)->IsWantReturn()) return std::nullopt;
+			}
 			// Tabbing between controls
 			if (wParam == VK_TAB) {
-				if (m_pFocus && m_pFocus->IsVisible () && m_pFocus->IsEnabled () && m_pFocus->GetClass ().find (_T ("RichEditUI")) != faw::string_t::npos) {
+				if (m_pFocus && m_pFocus->IsVisible () && m_pFocus->IsEnabled () && m_pFocus->GetClass ().find (_T ("RichEdit")) != faw::string_t::npos) {
 					if (dynamic_cast<CRichEditUI*>(m_pFocus)->IsWantTab ()) return std::nullopt;
 				}
 				if (m_pFocus && m_pFocus->IsVisible () && m_pFocus->IsEnabled () && m_pFocus->GetClass ().find (_T ("WkeWebkitUI")) != faw::string_t::npos) {
@@ -1977,7 +1981,7 @@ namespace DuiLib {
 		}
 		RebuildFont (&m_SharedResInfo.m_DefaultFontInfo);
 
-		CStdPtrArray *richEditList = FindSubControlsByClass (GetRoot (), _T ("RichEditUI"));
+		CStdPtrArray *richEditList = FindSubControlsByClass (GetRoot (), _T ("RichEdit"));
 		for (int i = 0; i < richEditList->GetSize (); i++) {
 			CRichEditUI* pT = static_cast<CRichEditUI*>((*richEditList)[i]);
 			pT->SetFont (pT->GetFont ());

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -699,10 +699,6 @@ namespace DuiLib {
 		switch (uMsg) {
 		case WM_KEYDOWN:
 		{
-			if (wParam == VK_RETURN) {
-				if (m_pFocus && m_pFocus->IsVisible() && m_pFocus->IsEnabled() && m_pFocus->GetClass().find(_T("RichEdit")) != faw::string_t::npos)
-					if (dynamic_cast<CRichEditUI*>(m_pFocus)->IsWantReturn()) return std::nullopt;
-			}
 			// Tabbing between controls
 			if (wParam == VK_TAB) {
 				if (m_pFocus && m_pFocus->IsVisible () && m_pFocus->IsEnabled () && m_pFocus->GetClass ().find (_T ("RichEdit")) != faw::string_t::npos) {

--- a/DuiLib/Utils/WinImplBase.cpp
+++ b/DuiLib/Utils/WinImplBase.cpp
@@ -42,8 +42,11 @@ namespace DuiLib {
 
 	std::optional<LRESULT> WindowImplBase::MessageHandler (UINT uMsg, WPARAM wParam, LPARAM /*lParam*/) {
 		if (uMsg == WM_KEYDOWN) {
+			auto pFocus = m_pm.GetFocus();
 			switch (wParam) {
 			case VK_RETURN:
+				if (pFocus && pFocus->IsVisible() && pFocus->IsEnabled() && pFocus->GetClass().find(_T("RichEdit")) != faw::string_t::npos)
+					if (dynamic_cast<CRichEditUI*>(pFocus)->IsWantReturn()) return std::nullopt;
 			case VK_ESCAPE:
 				return ResponseDefaultKeyEvent (wParam);
 			default:


### PR DESCRIPTION
1.RichEdit的文字可以正常响应DPI
2.RichEdit可以发送duilib的DUI_MSGTYPE_RETURN事件
3.回退代码,修复布局错误问题