### PR TITLE
1.修复菜单图标消失 2.Combo中字体二次缩放导致文字过大

### DIFF
--- a/DuiLib/Control/UICombo.cpp
+++ b/DuiLib/Control/UICombo.cpp
@@ -58,9 +58,9 @@ namespace DuiLib {
 		RECT rcInset = m_pOwner->GetDropBoxInset ();
 		RECT rcOwner = pOwner->GetPos ();
 		RECT rc = rcOwner;
-		auto Scale = pOwner->GetManager()->GetDPIObj()->GetScale();
+		auto Scale = pOwner->GetManager ()->GetDPIObj ()->GetScale ();
 		if (Scale > 100)
-			rc.right = rc.left + pOwner->GetWidth() * 100 / Scale;
+			rc.right = rc.left + pOwner->GetWidth () * 100 / Scale;
 		rc.top = rc.bottom;		// 父窗口left、bottom位置作为弹出窗口起点
 		rc.bottom = rc.top + szDrop.cy;	// 计算弹出窗口高度
 		if (szDrop.cx > 0) rc.right = rc.left + szDrop.cx;	// 计算弹出窗口宽度
@@ -158,12 +158,12 @@ namespace DuiLib {
 			m_pm.AttachDialog (m_pLayout);
 			m_pm.AddNotifier (this);
 			//默认字体为shared,在主窗体已经DPI调整,此处需要还原
-			m_pm.SetDPI(CDPI::GetMainMonitorDPI());
-			auto scale = m_pm.GetDPIObj()->GetScale();
+			m_pm.SetDPI (CDPI::GetMainMonitorDPI ());
+			auto scale = m_pm.GetDPIObj ()->GetScale ();
 			if (scale > 100)
 			{
-				auto fontinfo = m_pm.GetDefaultFontInfo();
-				m_pm.SetDefaultFont(fontinfo->sFontName, (int)(fontinfo->iSize * 100.0 / scale), fontinfo->bBold, fontinfo->bUnderline, fontinfo->bItalic, false);
+				auto fontinfo = m_pm.GetDefaultFontInfo ();
+				m_pm.SetDefaultFont (fontinfo->sFontName, (int) (fontinfo->iSize * 100.0 / scale), fontinfo->bBold, fontinfo->bUnderline, fontinfo->bItalic, false);
 			}
 			return 0;
 		} else if (uMsg == WM_CLOSE) {

--- a/DuiLib/Control/UICombo.cpp
+++ b/DuiLib/Control/UICombo.cpp
@@ -58,6 +58,9 @@ namespace DuiLib {
 		RECT rcInset = m_pOwner->GetDropBoxInset ();
 		RECT rcOwner = pOwner->GetPos ();
 		RECT rc = rcOwner;
+		auto Scale = pOwner->GetManager()->GetDPIObj()->GetScale();
+		if (Scale > 100)
+			rc.right = rc.left + pOwner->GetWidth() * 100 / Scale;
 		rc.top = rc.bottom;		// 父窗口left、bottom位置作为弹出窗口起点
 		rc.bottom = rc.top + szDrop.cy;	// 计算弹出窗口高度
 		if (szDrop.cx > 0) rc.right = rc.left + szDrop.cx;	// 计算弹出窗口宽度
@@ -154,6 +157,14 @@ namespace DuiLib {
 			m_pm.GetShadow ()->ShowShadow (m_pOwner->IsShowShadow ());
 			m_pm.AttachDialog (m_pLayout);
 			m_pm.AddNotifier (this);
+			//默认字体为shared,在主窗体已经DPI调整,此处需要还原
+			m_pm.SetDPI(CDPI::GetMainMonitorDPI());
+			auto scale = m_pm.GetDPIObj()->GetScale();
+			if (scale > 100)
+			{
+				auto fontinfo = m_pm.GetDefaultFontInfo();
+				m_pm.SetDefaultFont(fontinfo->sFontName, (int)(fontinfo->iSize * 100.0 / scale), fontinfo->bBold, fontinfo->bUnderline, fontinfo->bItalic, false);
+			}
 			return 0;
 		} else if (uMsg == WM_CLOSE) {
 			m_pOwner->SetManager (m_pOwner->GetManager (), m_pOwner->GetParent (), false);

--- a/DuiLib/Control/UIMenu.cpp
+++ b/DuiLib/Control/UIMenu.cpp
@@ -263,7 +263,7 @@ namespace DuiLib {
 			// 内部创建的内部删除
 			delete this;
 		} else {
-			DestroyMenu ();
+			// DestroyMenu ();
 			// 外部创建的也删除
 			delete this;
 		}

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -2691,6 +2691,7 @@ namespace DuiLib {
 		pCollection->GetFamilies(count, pFontFamily, &found);
 		if (found == 0) {
 			free(pFontFamily);
+			delete pCollection;
 			return;
 		}
 		// 获取字体名称
@@ -2698,15 +2699,16 @@ namespace DuiLib {
 		pFontFamily->GetFamilyName(fontFamilyName);
 		free(pFontFamily);
 
+#ifdef _UNICODE
 		if (!m_mGDIPlusFontCollection.Find(fontFamilyName))
-		{
 			m_mGDIPlusFontCollection.Set(fontFamilyName, pCollection);
-		}
+#else
+		auto FontFamilyName = FawTools::utf16_to_gb18030(fontFamilyName);
+		if (!m_mGDIPlusFontCollection.Find(FontFamilyName))
+			m_mGDIPlusFontCollection.Set(FontFamilyName, pCollection);
+#endif // _UNICODE
 		else
-		{
 			delete pCollection;
-			return;
-		}
 	}
 	HFONT CPaintManagerUI::GetFont (int id) {
 		if (id < 0) return GetDefaultFontInfo ()->hFont;

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -258,7 +258,7 @@ namespace DuiLib {
 		RemoveAllOptionGroups ();
 		RemoveAllTimers ();
 		RemoveAllDrawInfos ();
-		RemoveResourceFontCollection();
+		RemoveResourceFontCollection ();
 
 		if (m_hwndTooltip) {
 			::DestroyWindow (m_hwndTooltip);
@@ -299,7 +299,7 @@ namespace DuiLib {
 		RemoveAllWindowCustomAttribute ();
 		RemoveAllOptionGroups ();
 		RemoveAllTimers ();
-		RemoveResourceFontCollection();
+		RemoveResourceFontCollection ();
 
 		m_sName.clear ();
 		if (!pstrName.empty ()) m_sName = pstrName;
@@ -2527,9 +2527,9 @@ namespace DuiLib {
 				return _font;
 		}
 		//AddFontMemResourceEx添加的字体找不到,先创建看看,可以创建就可以用
-		if (_fonts.length() > 0) {
-			_tcsncpy(_lf.lfFaceName, _fonts.data(), lengthof(_lf.lfFaceName));
-			HFONT hFont = ::CreateFontIndirect(&_lf);
+		if (_fonts.length () > 0) {
+			_tcsncpy (_lf.lfFaceName, _fonts.data (), lengthof (_lf.lfFaceName));
+			HFONT hFont = ::CreateFontIndirect (&_lf);
 			if (hFont) return _fonts;
 		}
 		return _T ("Microsoft YaHei");
@@ -2670,42 +2670,41 @@ namespace DuiLib {
 
 		DWORD nFonts;
 		//AddFontMemResourceEx 添加的字体始终是发出调用且不可枚举的进程专用的。
-		HANDLE hFont = ::AddFontMemResourceEx(pData, dwSize, nullptr, &nFonts);
-		m_aFonts.Add(hFont);
+		HANDLE hFont = ::AddFontMemResourceEx (pData, dwSize, nullptr, &nFonts);
+		m_aFonts.Add (hFont);
 
 		// 添加字体
-		Gdiplus::PrivateFontCollection* pCollection = new Gdiplus::PrivateFontCollection();
-		pCollection->AddMemoryFont(pData, dwSize);
+		Gdiplus::PrivateFontCollection* pCollection = new Gdiplus::PrivateFontCollection ();
+		pCollection->AddMemoryFont (pData, dwSize);
 		delete[] pData;
 		pData = nullptr;
 
-		int count = pCollection->GetFamilyCount();
-		if (count == 0)
-		{
+		int count = pCollection->GetFamilyCount ();
+		if (count == 0) {
 			delete pCollection;
 			return;
 		}
 
 		int found = 0;
-		Gdiplus::FontFamily* pFontFamily = (Gdiplus::FontFamily*)malloc(count * sizeof(Gdiplus::FontFamily));
-		pCollection->GetFamilies(count, pFontFamily, &found);
+		Gdiplus::FontFamily* pFontFamily = (Gdiplus::FontFamily*) malloc (count * sizeof (Gdiplus::FontFamily));
+		pCollection->GetFamilies (count, pFontFamily, &found);
 		if (found == 0) {
-			free(pFontFamily);
+			free (pFontFamily);
 			delete pCollection;
 			return;
 		}
 		// 获取字体名称
 		WCHAR  fontFamilyName[MAX_PATH] = { 0 };
-		pFontFamily->GetFamilyName(fontFamilyName);
-		free(pFontFamily);
+		pFontFamily->GetFamilyName (fontFamilyName);
+		free (pFontFamily);
 
 #ifdef _UNICODE
-		if (!m_mGDIPlusFontCollection.Find(fontFamilyName))
-			m_mGDIPlusFontCollection.Set(fontFamilyName, pCollection);
+		if (!m_mGDIPlusFontCollection.Find (fontFamilyName))
+			m_mGDIPlusFontCollection.Set (fontFamilyName, pCollection);
 #else
-		auto FontFamilyName = FawTools::utf16_to_gb18030(fontFamilyName);
-		if (!m_mGDIPlusFontCollection.Find(FontFamilyName))
-			m_mGDIPlusFontCollection.Set(FontFamilyName, pCollection);
+		auto FontFamilyName = FawTools::utf16_to_gb18030 (fontFamilyName);
+		if (!m_mGDIPlusFontCollection.Find (FontFamilyName))
+			m_mGDIPlusFontCollection.Set (FontFamilyName, pCollection);
 #endif // _UNICODE
 		else
 			delete pCollection;
@@ -2746,17 +2745,15 @@ namespace DuiLib {
 		return nullptr;
 	}
 
-	Gdiplus::Font* CPaintManagerUI::GetResourceFont(faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
+	Gdiplus::Font* CPaintManagerUI::GetResourceFont (faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
 	{
-		auto pCollection = (Gdiplus::PrivateFontCollection*)m_mGDIPlusFontCollection.Find(pStrFontName);
-		if (pCollection)
-		{
+		auto pCollection = (Gdiplus::PrivateFontCollection*) m_mGDIPlusFontCollection.Find (pStrFontName);
+		if (pCollection) {
 			Gdiplus::FontFamily fontFamily;
 			int nNumFound = 0;
-			pCollection->GetFamilies(1, &fontFamily, &nNumFound);
+			pCollection->GetFamilies (1, &fontFamily, &nNumFound);
 
-			if (nNumFound > 0)
-			{
+			if (nNumFound > 0) {
 				int fontStyle = Gdiplus::FontStyle::FontStyleRegular;
 				if (bBold && bItalic)
 					fontStyle = Gdiplus::FontStyle::FontStyleBoldItalic;
@@ -2766,11 +2763,11 @@ namespace DuiLib {
 					fontStyle = Gdiplus::FontStyle::FontStyleUnderline;
 				else if (bItalic)
 					fontStyle = Gdiplus::FontStyle::FontStyleItalic;
-				Gdiplus::Font* font = Gdiplus::Font(&fontFamily, nSize, fontStyle, Gdiplus::Unit::UnitPixel).Clone();
+				Gdiplus::Font* font = Gdiplus::Font (&fontFamily, nSize, fontStyle, Gdiplus::Unit::UnitPixel).Clone ();
 				return font;
 			}
 		}
-		return Gdiplus::Font(GetDC(NULL), GetFont(-1)).Clone();
+		return Gdiplus::Font (GetDC (NULL), GetFont (-1)).Clone ();
 	}
 
 	int CPaintManagerUI::GetFontIndex (HFONT hFont, bool bShared) {
@@ -2906,17 +2903,17 @@ namespace DuiLib {
 		}
 	}
 
-	void CPaintManagerUI::RemoveResourceFontCollection()
+	void CPaintManagerUI::RemoveResourceFontCollection ()
 	{
-		for (int i = 0; i < m_mGDIPlusFontCollection.GetSize(); i++) {
-			faw::string_t key = m_mGDIPlusFontCollection.GetAt(i)->Key;
-			if (!key.empty()) {
-				auto FontCollection = static_cast<Gdiplus::PrivateFontCollection*>(m_mGDIPlusFontCollection.Find(key, false));
+		for (int i = 0; i < m_mGDIPlusFontCollection.GetSize (); i++) {
+			faw::string_t key = m_mGDIPlusFontCollection.GetAt (i)->Key;
+			if (!key.empty ()) {
+				auto FontCollection = static_cast<Gdiplus::PrivateFontCollection*> (m_mGDIPlusFontCollection.Find (key, false));
 				if (FontCollection)
 					delete FontCollection;
 			}
 		}
-		m_mGDIPlusFontCollection.RemoveAll();
+		m_mGDIPlusFontCollection.RemoveAll ();
 	}
 
 	TFontInfo* CPaintManagerUI::GetFontInfo (int id) {

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -258,6 +258,7 @@ namespace DuiLib {
 		RemoveAllOptionGroups ();
 		RemoveAllTimers ();
 		RemoveAllDrawInfos ();
+		RemoveResourceFontCollection();
 
 		if (m_hwndTooltip) {
 			::DestroyWindow (m_hwndTooltip);
@@ -298,6 +299,7 @@ namespace DuiLib {
 		RemoveAllWindowCustomAttribute ();
 		RemoveAllOptionGroups ();
 		RemoveAllTimers ();
+		RemoveResourceFontCollection();
 
 		m_sName.clear ();
 		if (!pstrName.empty ()) m_sName = pstrName;
@@ -2524,6 +2526,12 @@ namespace DuiLib {
 			if (EnumFontFamiliesEx (_dc, &_lf, (FONTENUMPROC) _enum_font_cb, 0, 0) == 10)
 				return _font;
 		}
+		//AddFontMemResourceEx添加的字体找不到,先创建看看,可以创建就可以用
+		if (_fonts.length() > 0) {
+			_tcsncpy(_lf.lfFaceName, _fonts.data(), lengthof(_lf.lfFaceName));
+			HFONT hFont = ::CreateFontIndirect(&_lf);
+			if (hFont) return _fonts;
+		}
 		return _T ("Microsoft YaHei");
 	}
 
@@ -2658,11 +2666,47 @@ namespace DuiLib {
 			}
 			break;
 		}
+		if (!pData || dwSize == 0) return;
+
 		DWORD nFonts;
-		HANDLE hFont = ::AddFontMemResourceEx (pData, dwSize, nullptr, &nFonts);
+		//AddFontMemResourceEx 添加的字体始终是发出调用且不可枚举的进程专用的。
+		HANDLE hFont = ::AddFontMemResourceEx(pData, dwSize, nullptr, &nFonts);
+		m_aFonts.Add(hFont);
+
+		// 添加字体
+		Gdiplus::PrivateFontCollection* pCollection = new Gdiplus::PrivateFontCollection();
+		pCollection->AddMemoryFont(pData, dwSize);
 		delete[] pData;
 		pData = nullptr;
-		m_aFonts.Add (hFont);
+
+		int count = pCollection->GetFamilyCount();
+		if (count == 0)
+		{
+			delete pCollection;
+			return;
+		}
+
+		int found = 0;
+		Gdiplus::FontFamily* pFontFamily = (Gdiplus::FontFamily*)malloc(count * sizeof(Gdiplus::FontFamily));
+		pCollection->GetFamilies(count, pFontFamily, &found);
+		if (found == 0) {
+			free(pFontFamily);
+			return;
+		}
+		// 获取字体名称
+		WCHAR  fontFamilyName[MAX_PATH] = { 0 };
+		pFontFamily->GetFamilyName(fontFamilyName);
+		free(pFontFamily);
+
+		if (!m_mGDIPlusFontCollection.Find(fontFamilyName))
+		{
+			m_mGDIPlusFontCollection.Set(fontFamilyName, pCollection);
+		}
+		else
+		{
+			delete pCollection;
+			return;
+		}
 	}
 	HFONT CPaintManagerUI::GetFont (int id) {
 		if (id < 0) return GetDefaultFontInfo ()->hFont;
@@ -2698,6 +2742,33 @@ namespace DuiLib {
 		}
 
 		return nullptr;
+	}
+
+	Gdiplus::Font* CPaintManagerUI::GetResourceFont(faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
+	{
+		auto pCollection = (Gdiplus::PrivateFontCollection*)m_mGDIPlusFontCollection.Find(pStrFontName);
+		if (pCollection)
+		{
+			Gdiplus::FontFamily fontFamily;
+			int nNumFound = 0;
+			pCollection->GetFamilies(1, &fontFamily, &nNumFound);
+
+			if (nNumFound > 0)
+			{
+				int fontStyle = Gdiplus::FontStyle::FontStyleRegular;
+				if (bBold && bItalic)
+					fontStyle = Gdiplus::FontStyle::FontStyleBoldItalic;
+				else if (bBold)
+					fontStyle = Gdiplus::FontStyle::FontStyleBold;
+				else if (bUnderline)
+					fontStyle = Gdiplus::FontStyle::FontStyleUnderline;
+				else if (bItalic)
+					fontStyle = Gdiplus::FontStyle::FontStyleItalic;
+				Gdiplus::Font* font = Gdiplus::Font(&fontFamily, nSize, fontStyle, Gdiplus::Unit::UnitPixel).Clone();
+				return font;
+			}
+		}
+		return Gdiplus::Font(GetDC(NULL), GetFont(-1)).Clone();
 	}
 
 	int CPaintManagerUI::GetFontIndex (HFONT hFont, bool bShared) {
@@ -2831,6 +2902,19 @@ namespace DuiLib {
 			}
 			m_ResInfo.m_CustomFonts.RemoveAll ();
 		}
+	}
+
+	void CPaintManagerUI::RemoveResourceFontCollection()
+	{
+		for (int i = 0; i < m_mGDIPlusFontCollection.GetSize(); i++) {
+			faw::string_t key = m_mGDIPlusFontCollection.GetAt(i)->Key;
+			if (!key.empty()) {
+				auto FontCollection = static_cast<Gdiplus::PrivateFontCollection*>(m_mGDIPlusFontCollection.Find(key, false));
+				if (FontCollection)
+					delete FontCollection;
+			}
+		}
+		m_mGDIPlusFontCollection.RemoveAll();
 	}
 
 	TFontInfo* CPaintManagerUI::GetFontInfo (int id) {

--- a/DuiLib/Core/UIManager.h
+++ b/DuiLib/Core/UIManager.h
@@ -315,11 +315,13 @@ namespace DuiLib {
 		HFONT AddFont (int id, faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic, bool bShared = false);
 		HFONT GetFont (int id);
 		HFONT GetFont (faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic);
+		Gdiplus::Font* GetResourceFont(faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic);
 		int GetFontIndex (HFONT hFont, bool bShared = false);
 		int GetFontIndex (faw::string_t pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic, bool bShared = false);
 		void RemoveFont (HFONT hFont, bool bShared = false);
 		void RemoveFont (int id, bool bShared = false);
 		void RemoveAllFonts (bool bShared = false);
+		void RemoveResourceFontCollection();
 		TFontInfo* GetFontInfo (int id);
 		TFontInfo* GetFontInfo (HFONT hFont);
 
@@ -524,6 +526,7 @@ namespace DuiLib {
 		CStdStringPtrMap m_mNameHash;
 		CStdStringPtrMap m_mWindowCustomAttrHash;
 		CStdStringPtrMap m_mOptionGroup;
+		CStdStringPtrMap m_mGDIPlusFontCollection;
 
 		bool m_bForceUseSharedRes;
 		TResInfo m_ResInfo;

--- a/DuiLib/Core/UIManager.h
+++ b/DuiLib/Core/UIManager.h
@@ -321,7 +321,7 @@ namespace DuiLib {
 		void RemoveFont (HFONT hFont, bool bShared = false);
 		void RemoveFont (int id, bool bShared = false);
 		void RemoveAllFonts (bool bShared = false);
-		void RemoveResourceFontCollection();
+		void RemoveResourceFontCollection ();
 		TFontInfo* GetFontInfo (int id);
 		TFontInfo* GetFontInfo (HFONT hFont);
 

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -1596,6 +1596,7 @@ namespace DuiLib {
 			} else {
 				graphics.DrawString (pcwszDest.data (), -1, font, rectF, &stringFormat, &brush);
 			}
+			delete font;
 			::SelectObject (hDC, hOldFont);
 		} else {
 			::SetBkMode (hDC, TRANSPARENT);

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -1528,7 +1528,13 @@ namespace DuiLib {
 		if (pManager->IsLayered () || pManager->IsUseGdiplusText ()) {
 			HFONT hOldFont = (HFONT)::SelectObject (hDC, pManager->GetFont (iFont));
 			Gdiplus::Graphics graphics (hDC);
-			Gdiplus::Font font (hDC, pManager->GetFont (iFont));
+			Gdiplus::Font* font = Gdiplus::Font(hDC, pManager->GetFont(iFont)).Clone();
+			if (font->GetLastStatus() != 0) 
+			{
+				delete font;
+				auto info = pManager->GetFontInfo(iFont);
+				font = pManager->GetResourceFont(info->sFontName, info->iSize, info->bBold, info->bUnderline, info->bItalic);
+			}
 			Gdiplus::TextRenderingHint trh = Gdiplus::TextRenderingHintSystemDefault;
 			switch (pManager->GetGdiplusTextRenderingHint ()) {
 			case 0: trh = Gdiplus::TextRenderingHintSystemDefault; break;
@@ -1583,12 +1589,12 @@ namespace DuiLib {
 			std::wstring pcwszDest = FawTools::T_to_utf16 (pstrText);
 			if ((uStyle & DT_CALCRECT) != 0) {
 				Gdiplus::RectF bounds;
-				graphics.MeasureString (pcwszDest.data (), -1, &font, rectF, &stringFormat, &bounds);
+				graphics.MeasureString (pcwszDest.data (), -1, font, rectF, &stringFormat, &bounds);
 				// MeasureString存在计算误差，这里加一像素
 				rc.bottom = rc.top + (long) bounds.Height + 1;
 				rc.right = rc.left + (long) bounds.Width + 1;
 			} else {
-				graphics.DrawString (pcwszDest.data (), -1, &font, rectF, &stringFormat, &brush);
+				graphics.DrawString (pcwszDest.data (), -1, font, rectF, &stringFormat, &brush);
 			}
 			::SelectObject (hDC, hOldFont);
 		} else {

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -1528,12 +1528,12 @@ namespace DuiLib {
 		if (pManager->IsLayered () || pManager->IsUseGdiplusText ()) {
 			HFONT hOldFont = (HFONT)::SelectObject (hDC, pManager->GetFont (iFont));
 			Gdiplus::Graphics graphics (hDC);
-			Gdiplus::Font* font = Gdiplus::Font(hDC, pManager->GetFont(iFont)).Clone();
-			if (font->GetLastStatus() != 0) 
+			Gdiplus::Font* font = Gdiplus::Font (hDC, pManager->GetFont (iFont)).Clone ();
+			if (font->GetLastStatus () != 0) 
 			{
 				delete font;
-				auto info = pManager->GetFontInfo(iFont);
-				font = pManager->GetResourceFont(info->sFontName, info->iSize, info->bBold, info->bUnderline, info->bItalic);
+				auto info = pManager->GetFontInfo (iFont);
+				font = pManager->GetResourceFont (info->sFontName, info->iSize, info->bBold, info->bUnderline, info->bItalic);
 			}
 			Gdiplus::TextRenderingHint trh = Gdiplus::TextRenderingHintSystemDefault;
 			switch (pManager->GetGdiplusTextRenderingHint ()) {


### PR DESCRIPTION
1.修复菜单静态资源跟随菜单窗体销毁,导致后续新菜单找不到静态资源而出现菜单图标消失 
2.修复UICombo子窗口二次缩放字体(主窗体已缩放过一次)导致的字体过大