### PR TITLE
fix CListUI::GetClientPos()

### DIFF
--- a/DuiLib/Control/UILabel.cpp
+++ b/DuiLib/Control/UILabel.cpp
@@ -98,7 +98,7 @@ namespace DuiLib {
 			m_szAvailableLast = szAvailable;
 			m_cxyFixedLast = m_cxyFixed;
 			if (sText.empty())
-				return { 0,0 };
+				return { m_cxyFixed.cx , m_cxyFixed.cy };
 			// 自动计算宽度
 			if ((m_uTextStyle & DT_SINGLELINE) != 0) {
 				// 高度

--- a/DuiLib/Control/UIList.cpp
+++ b/DuiLib/Control/UIList.cpp
@@ -390,6 +390,31 @@ namespace DuiLib {
 		Invalidate ();
 	}
 
+	RECT CListUI::GetClientPos() const
+	{
+		RECT rc = m_rcItem;
+		rc.left += m_rcInset.left;
+		rc.top += m_rcInset.top;
+		rc.right -= m_rcInset.right;
+		rc.bottom -= m_rcInset.bottom;
+
+		if (GetVerticalScrollBar() && GetVerticalScrollBar()->IsVisible()) {
+			auto m_pVerticalScrollBar = GetVerticalScrollBar();
+			rc.top -= m_pVerticalScrollBar->GetScrollPos();
+			rc.bottom -= m_pVerticalScrollBar->GetScrollPos();
+			rc.bottom += m_pVerticalScrollBar->GetScrollRange();
+			rc.right -= m_pVerticalScrollBar->GetFixedWidth();
+		}
+		if (GetHorizontalScrollBar() && GetHorizontalScrollBar()->IsVisible()) {
+			auto m_pHorizontalScrollBar = GetVerticalScrollBar();
+			rc.left -= m_pHorizontalScrollBar->GetScrollPos();
+			rc.right -= m_pHorizontalScrollBar->GetScrollPos();
+			rc.right += m_pHorizontalScrollBar->GetScrollRange();
+			rc.bottom -= m_pHorizontalScrollBar->GetFixedHeight();
+		}
+		return rc;
+	}
+
 	CListHeaderUI* CListUI::GetHeader () const {
 		return m_pHeader;
 	}

--- a/DuiLib/Control/UIList.h
+++ b/DuiLib/Control/UIList.h
@@ -125,6 +125,7 @@ namespace DuiLib {
 
 		bool IsFixedScrollbar ();
 		void SetFixedScrollbar (bool bFixed);
+		RECT GetClientPos() const override;
 
 		CListHeaderUI* GetHeader () const;
 		CContainerUI* GetList () const;


### PR DESCRIPTION
CListUI没有滚动条,实际作用的是m_pList的滚动条,GetClientPos应该剔除m_pList的滚动条,而不是CListUI的滚动条.所以override GetClientPos.

```
	CScrollBarUI* CListUI::GetVerticalScrollBar () const {
		return m_pList->GetVerticalScrollBar ();
	}

	CScrollBarUI* CListUI::GetHorizontalScrollBar () const {
		return m_pList->GetHorizontalScrollBar ();
	}
```